### PR TITLE
added members intent

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,11 @@ import asyncio
 
 token = 'BOT TOKEN HERE'
 
-client = discord.Client()
+
+intents = discord.Intents.default()
+intents.members = True
+
+client = discord.Client(intents=intents)
 
 @client.event
 async def on_ready():


### PR DESCRIPTION
Due to changes in the discord API, getting all members in a server requires the members intent.  The members intent must also be enabled on https://discord.com/developers.